### PR TITLE
Update Documentation for APT Repository Version Lag

### DIFF
--- a/docs/sources/setup/install/local.md
+++ b/docs/sources/setup/install/local.md
@@ -31,6 +31,11 @@ The configuration runs Loki as a single binary.
       apt-get install loki promtail
       ```
 
+Note: In rare cases the APT repository might temporarily lag behind the latest GitHub releases (for example, when versions such as 3.5.4 or 3.5.5 are not yet visible on https://apt.grafana.com). If you need a version that is not available via APT, use one of the following workarounds:
+- Install the desired version manually from the [GitHub Releases page](https://github.com/grafana/loki/releases) (download the appropriate Loki and Promtail assets for your platform).
+- Use container images from Docker Hub or ghcr.io for the required version.
+- If you prefer RPM-based distributions, check https://rpm.grafana.com where the latest packages may be available sooner.
+
 ## Install manually
 
 1. Browse to the [release page](https://github.com/grafana/loki/releases/).


### PR DESCRIPTION
This PR modifies the documentation to address the issue where the APT repository at apt.grafana.com is missing the latest versions of Loki (3.5.4 and 3.5.5). The update clarifies that there may be situations where the APT repository lags behind the latest GitHub releases. To mitigate this, it offers alternative options for users such as manually installing from the GitHub Releases page, using Docker images, or checking RPM repositories for the latest packages. This should help users who encounter the issue and provide them with actionable steps until the repository is updated.

---

> This pull request was co-created with Cosine Genie

Original Task: [loki/itpmpjgam0ny](https://cosine.sh/elefatcosine/loki/task/itpmpjgam0ny)
Author: Eleftheria Batsou
