### PR TITLE
Fix malformed query strings in redirect handler

### DIFF
--- a/pkg/ui/handler.go
+++ b/pkg/ui/handler.go
@@ -179,7 +179,10 @@ func (s *Service) notFoundHandler() http.Handler {
 // redirectToNotFound updates the request URL to redirect to the not found handler
 func (s *Service) redirectToNotFound(r *http.Request, nodeName string) {
 	r.URL.Path = notFoundPath
-	r.URL.RawQuery = "?node=" + nodeName
+
+	// RawQuery should not include a leading '?' per net/url expectations.
+	// Using it here was causing malformed query strings in some cases.
+	r.URL.RawQuery = "node=" + nodeName
 }
 
 // writeJSONError writes a JSON error response with the given status code and message


### PR DESCRIPTION
This PR addresses issue #19334, which was causing a "Failed to fetch ring in UI" error. I modified the `redirectToNotFound` function in `pkg/ui/handler.go` to correctly format the `RawQuery` parameter without leading '?', thus preventing malformed query strings in the URL. This change ensures that nodes are displayed correctly without triggering errors on the UI, thereby improving the overall user experience. All tests were run successfully and the functionality works as expected.

---

> This pull request was co-created with Cosine Genie

Original Task: [loki/7ib3t3fywtpw](https://cosine.sh/elefatcosine/loki/task/7ib3t3fywtpw)
Author: Eleftheria Batsou
